### PR TITLE
switch: Notify monitor connection on initialization

### DIFF
--- a/src/switch_init.c
+++ b/src/switch_init.c
@@ -90,7 +90,8 @@ int _glfwPlatformInit(void)
     _glfwSwitchRefreshFocusState();
     _glfwSwitchRefreshScreenSize();
 
-    _glfwAllocMonitor("Default", 1920, 1080);
+    _GLFWmonitor* monitor = _glfwAllocMonitor("Default", 1920, 1080);
+    _glfwInputMonitor(monitor, GLFW_CONNECTED, _GLFW_INSERT_FIRST);
     _glfwInitSwitchJoysticks();
     return GLFW_TRUE;
 }


### PR DESCRIPTION
Previously, the code only called `_glfwAllocMonitor`, but this only creates a monitor and returns it. It doesn't signal anything or adds it to other monitor functions, so it doesn't do nothing on itself.

This PR uses `_glfwInputMonitor` on initialization with that created monitor to notify monitor connection to glfw. This initializes the `_glfw.monitors` array correctly, so programs that expect at least one monitor to be present don't crash.