### PR TITLE
Initial state for pad and signal input joystick

### DIFF
--- a/src/switch_joystick.c
+++ b/src/switch_joystick.c
@@ -119,6 +119,9 @@ void _glfwInitSwitchJoysticks(void)
     hidInitializeTouchScreen();
     
     js->mapping = &s_switchMapping;
+
+    padUpdate(&pad);
+    _glfwInputJoystick(js, GLFW_CONNECTED);
 }
 
 void _glfwUpdateSwitchJoysticks(void)


### PR DESCRIPTION
This signals joystick connection when creating it, so some callbacks get executed.
It also adds a `padUpdate` call on initialization, so the controller can be properly detected as connected (through `glfwJoystickPresent` -> `_glfwPlatformPollJoystick`) before `glfwPollEvents` is called.